### PR TITLE
pom: correct pgv artifact name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,7 +372,7 @@
                             <protocArtifact>com.google.protobuf:protoc:${proto.version}:exe:${os.detected.classifier}</protocArtifact>
                             <pluginParameter>lang=java</pluginParameter>
                             <pluginId>java-pgv</pluginId>
-                            <pluginArtifact>io.envoyproxy.protoc-gen-validate:protoc-gen-validate:${pgv.version}:exe:${os.detected.classifier}</pluginArtifact>
+                            <pluginArtifact>build.buf.protoc-gen-validate:protoc-gen-validate:${pgv.version}:exe:${os.detected.classifier}</pluginArtifact>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
The artifact had been renamed in
6ac32404812cdf8a6a3e3de9cd58ab8cc6289c32 but missed this instance.