### PR TITLE
Bump schema2proto version from 1.83 to 1.84

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <proto-backwards-compatibility.version>1.0.7</proto-backwards-compatibility.version>
         <proto.version>3.22.1</proto.version>
         <protobuf-maven-plugin.version>0.7.1</protobuf-maven-plugin.version>
-        <schema2proto.version>1.83</schema2proto.version>
+        <schema2proto.version>1.84</schema2proto.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
The schema2proto version 1.84 brings missing documentation of certain NeTEx types to the generated proto files.