### PR TITLE
Reintroduce derived_from_version_ref + derived_from_object_ref 

### DIFF
--- a/src/main/resources/xslt/remove_unwanted_structures.xslt
+++ b/src/main/resources/xslt/remove_unwanted_structures.xslt
@@ -13,10 +13,8 @@
 - data_source_ref
 - data_managed_object_ref
 - modification
-- derived_from_version_ref
 - compatible_with_version_frame_version_ref
 - responsibility_set_ref
-- derived_from_object_ref
 - branding_ref
 - publication
         -->
@@ -37,17 +35,6 @@
     <xsl:template match="/xsd:schema/xsd:attributeGroup[@name = 'DocumentModificationDetailsGroup']/xsd:attribute[@name = 'modification']"/>
     <xsl:template
         match="/xsd:schema/xsd:element[@name = 'DisplayAssignment']/xsd:complexType/xsd:complexContent/xsd:restriction[@base = 'DisplayAssignment_VersionStructure']/xsd:attribute[@name = 'dataSourceRef']"/>
-
-    <!-- derivedFromVersionRef attribute -->
-    <xsl:template match="/xsd:schema/xsd:attributeGroup[@name = 'BasicModificationDetailsGroup']/xsd:attribute[@name = 'derivedFromVersionRef']"/>
-    <xsl:template
-        match="/xsd:schema/xsd:element[@name = 'DisplayAssignment']/xsd:complexType/xsd:complexContent/xsd:restriction[@base = 'DisplayAssignment_VersionStructure']/xsd:attribute[@name = 'derivedFromVersionRef']"/>
-
-    <!-- derivedFromObjectRef attribute -->
-    <xsl:template match="/xsd:schema/xsd:attributeGroup[@name = 'BasicModificationDetailsGroup']/xsd:attribute[@name = 'derivedFromObjectRef']"/>
-    <xsl:template
-        match="/xsd:schema/xsd:element[@name = 'DisplayAssignment']/xsd:complexType/xsd:complexContent/xsd:restriction[@base = 'DisplayAssignment_VersionStructure']/xsd:attribute[@name = 'derivedFromObjectRef']"/>
-
 
     <!-- compatibleWithVersionFrameVersionRef attribute -->
     <xsl:template match="/xsd:schema/xsd:attributeGroup[@name = 'BasicModificationDetailsGroup']/xsd:attribute[@name = 'compatibleWithVersionFrameVersionRef']"/>


### PR DESCRIPTION
Fields are needed to track origin of custom / ad hoc GroupTickets created in fulfilment from Entur sales platform. The fields were removed when we were blocked by the size limitation on proto descriptor (could not exceed 1 mb) because of a bug in terraform provider. This is no longer an issue. Would ideally reintroduce with original field ids but could not find an efficient way of doing it as the original field numbering was not consistent for all types. 