### PR TITLE
Add LineType to NetworkValidityParametersGroup

### DIFF
--- a/src/main/resources/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/src/main/resources/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -443,6 +443,11 @@ Rail transport, Roads and Road transport
 				</xsd:annotation>
 			</xsd:group>
 			<xsd:element ref="MobilityServiceConstraintZoneRef" minOccurs="0"/>
+            <xsd:element name="LineType" type="LineTypeEnumeration" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Classification of LINE. +v1.1.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="SiteValidityParametersGroup">


### PR DESCRIPTION
This allows specifying `LineType` as validity scoping parameter for access rights and product validity parameters.

The sales system at Entur have added this to their models and transmodel based APIs already and will very soon start using this feature to prevent offers being presented to travellers for certain types of lines (flexible lines where ordinary tickets are not valid).

They are also planning to introduce this as a suggested addition to NeTE proper, but currently no new suggestions are welcome until after the 2.0 release scheduled for end of September (afaik). Even after the release it will probably be some time before it can be added. And even longer before we can include all changes into the proto model. 
 
I have confirmed with our NeTEx fares specialist that the change they will be creating a PR for in the CEN repo is similar to this PR with respect to:

1. field location (NetworkValidityParametersGroup)
2. field name ("LineType")
3. field type (LineTypeEnumeration)

Which is all that should matter for generating the protobuf. The ordering within NetworkValidityParametersGroupNetworkValidityParametersGroup, the formatting and the documentation may end up differently, but none of this should impact the generated proto format once we have generated the proto locks.

If, for some reason, it is rejected by CEN this will end up like other local changes we have in the NeTEx model. Worst case is that they somehow end up including a similar change using a different type. Can't really see it happening, but we would probably have to deprecate the field added by this PR and make some transitional logic before removing it. 

The product registry has also added support for the new line types already merged to the NeTEx 2.0 ("next") branch. Created a separate PR for this change: https://github.com/entur/netex-protobuf/pull/376


abt-protobuf: https://github.com/entur/abt-protobuf/pull/1518
inspection-lib: https://github.com/entur/abt-inspection-lib/pull/1328
abt-core: https://github.com/entur/abt-core/pull/4327

abt-referencedata and backoffice should also be updated, but can be done after merging