### PR TITLE
Disable sources and javadoc publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ If breaking changes needs to be accepted into the proto.lock file, run the follo
 `protolock commit --force --protoroot target/proto/`
 
 ## Publishing
-While project validates that sources / javadoc can be generated, only `.proto` files are published to Maven Central.
+A jar containing `.proto` files is published to Maven Central.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![MvnRepository](https://badges.mvnrepository.com/badge/no.entur/netex-protobuf/badge.svg?label=MvnRepository)](https://mvnrepository.com/artifact/no.entur/netex-protobuf)
+
 # NeTEx Protobuf definitions
 
 This project contains setup to generate [Protocol Buffers Definition files](https://protobuf.dev/) (`.proto` files) from the [NeTEx XML schema](https://github.com/entur/NeTEx).
@@ -22,3 +24,6 @@ There is a Maven profile `protoc` which is active by default. This profile perfo
 If breaking changes needs to be accepted into the proto.lock file, run the following command to update it (do not delete as `schema2proto` needs the file for backwards compatibility check as well)
 
 `protolock commit --force --protoroot target/proto/`
+
+## Publishing
+While project validates that sources / javadoc can be generated, only `.proto` files are published to Maven Central.

--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,9 @@
                                         <active>RELEASE</active>
                                         <url>https://central.sonatype.com/api/v1/publisher</url>
                                         <stagingRepositories>target/staging-deploy</stagingRepositories>
+                                        <!-- avoid publishing enormous javadoc/source artifacts to maven central -->
+                                        <sourceJar>false</sourceJar>
+                                        <javadocJar>false</javadocJar>
                                     </sonatype>
                                 </mavenCentral>
                                 <nexus2>
@@ -362,6 +365,9 @@
                                         <closeRepository>true</closeRepository>
                                         <releaseRepository>true</releaseRepository>
                                         <stagingRepositories>target/staging-deploy</stagingRepositories>
+                                        <!-- avoid publishing enormous javadoc/source artifacts to maven central -->
+                                        <sourceJar>false</sourceJar>
+                                        <javadocJar>false</javadocJar>
                                     </maven-central>
                                 </nexus2>
                             </maven>


### PR DESCRIPTION
Currently publishing enormous sources/javadoc which are not backed by the jar.