### PR TITLE
Disable sources and javadoc publishing - attempt 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,15 @@ Backwards compatibility check is handled by `protolock` (https://github.com/nils
 `mvn clean install`
 
 NOTE:
-There is a Maven profile `protoc` which is active by default. This profile performs Java compilation of the generated stubs, and is meant only as a step to verify that the protoc compiler can handle the resulting proto. The compilation step is heavy. To run without use
+There is three Maven profiles which are active by default:
 
-`mvn clean install -P'!protoc'`
+ * `protoc` This profile performs Java compilation of the generated stubs
+ * `javadoc` This profile generates javadoc jar for the generated stubs
+ * `sources` This profile generates sources jar for the generated stubs
+
+These profiles are used to verify that the protoc compiler can handle the resulting proto. The compilation step is heavy. To run without use
+
+`mvn clean install -P'!protoc,!javadoc,!sources'`
 
 ## Handling breaking changes
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,29 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${maven-javadoc-plugin.version}</version>
+                    <configuration>
+                        <doclint>none</doclint>
+                        <source>17</source>
+                        <detectJavaApiLink>false</detectJavaApiLink>
+                        <minmemory>2048m</minmemory>
+                        <maxmemory>8192m</maxmemory>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                            <configuration>
+                                <attach>true</attach>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -311,29 +334,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven-javadoc-plugin.version}</version>
-                <configuration>
-                    <doclint>none</doclint>
-                    <source>17</source>
-                    <detectJavaApiLink>false</detectJavaApiLink>
-                    <minmemory>2048m</minmemory>
-                    <maxmemory>8192m</maxmemory>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <attach>true</attach>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.jreleaser</groupId>
                 <artifactId>jreleaser-maven-plugin</artifactId>
                 <inherited>false</inherited>
@@ -425,16 +425,26 @@
             </build>
         </profile>
         <profile>
-            <id>publication</id>
-            <properties>
-                <altDeploymentRepository>local::file:./target/staging-deploy</altDeploymentRepository>
-            </properties>
+            <id>javadoc</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>io.github.ascopes</groupId>
-                        <artifactId>protobuf-maven-plugin</artifactId>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>sources</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
@@ -453,6 +463,15 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>publication</id>
+            <properties>
+                <altDeploymentRepository>local::file:./target/staging-deploy</altDeploymentRepository>
+                <!-- be extra sure that javadoc and source artifacts are not published to maven central -->
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+                <maven.source.skip>true</maven.source.skip>
+            </properties>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Attempt 2, looks like we just disabled validation in the previous PR. 

Make use of profiles + properties to disable publishing javadoc and sources jar.

Local staging looks promising:
> mvn clean -Ppublication deploy -DaltDeploymentRepository=local::file:./target/staging-deploy